### PR TITLE
chore(github-actions): let's check for common typos in coding

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,29 @@
+name: Codespell
+
+on:
+  workflow_call:
+    inputs:
+      codespell-ignore:
+        description: 'Path to text file with words to be ignored'
+        required: true
+        default: '.github/config/wordlist.txt'
+        type: string
+      codespell-files-glob:
+        description: 'Files match pattern'
+        required: true
+        default: './**/*.y*ml ./**/*.go'
+        type: string
+
+jobs:
+  codespell:
+    name: codespell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install codespell
+        run: pip install codespell==2.3.0
+      - name: Check code for common misspellings
+        run: |
+          shopt -s globstar
+          codespell --count --ignore-words=${{ inputs.codespell-ignore }} ${{ inputs.codespell-files-glob }}


### PR DESCRIPTION
We do have quite a bunch of weird typos in our coding. Let's add a check which helps us to detect them.

Sample output, when executed on ocm repository:

```text
| ./api/config/internal/context.go:82: ony ==> only, on, one
| ./api/credentials/config/type.go:26: cosumer ==> consumer
| ./api/credentials/extensions/repositories/memory/config/type.go:34: othe ==> other
| ./api/credentials/extensions/repositories/vault/repo_int_test.go:133: unsufficient ==> insufficient
| ./api/credentials/extensions/repositories/vault/repo_int_test.go:172: respository ==> repository
| ./api/credentials/extensions/repositories/vault/repo_int_test.go:221: respository ==> repository
| ./api/credentials/internal/credentialsspec.go:71: ot ==> to, of, or, not, it
| ./api/datacontext/action/handlers/registry.go:182: selctor ==> selector, sector
| ./api/datacontext/config/attrs/type.go:26: descibe ==> describe
| ./api/datacontext/config/attrs/type.go:26: geeric ==> generic
| ./api/datacontext/context.go:158: atomicly ==> atomically
| ./api/helper/env/env.go:58: ot ==> to, of, or, not, it
| ./api/helper/env/env.go:286: faild ==> failed
| ./api/helper/env/env.go:300: faild ==> failed
| ./api/oci/extensions/repositories/ctf/synthesis_test.go:147: syntesized ==> synthesized
| ./api/ocm/compdesc/accessors.go:73: typicall ==> typically, typical
| ./api/ocm/compdesc/componentdescriptor.go:156: ist ==> is, it, its, it's, sit, list
| ./api/ocm/compdesc/copy_test.go:17: Descripor ==> Descriptor
| ./api/ocm/compdesc/equal.go:47: accoding ==> according
| ./api/ocm/compdesc/versions/ocm.software/v3alpha1/componentdescriptor.go:84: ist ==> is, it, its, it's, sit, list
| ./api/ocm/compdesc/versions/ocm.software/v3alpha1/validation_test.go:376: differnet ==> different
| ./api/ocm/compdesc/versions/v2/componentdescriptor.go:129: ist ==> is, it, its, it's, sit, list
| ./api/ocm/compdesc/versions/v2/validation_test.go:415: differnet ==> different
| ./api/ocm/cpi/repocpi/view_cv.go:82: retieves ==> retrieves
| ./api/ocm/extensions/accessmethods/compose/method.go:38: referencable ==> referenceable
| ./api/ocm/extensions/accessmethods/github/method_test.go:110: comsumer ==> consumer
| ./api/ocm/extensions/accessmethods/localblob/method.go:23: allways ==> always
| ./api/ocm/extensions/accessmethods/localblob/method.go:94: referencable ==> referenceable
| ./api/ocm/extensions/accessmethods/localblob/method.go:160: referencable ==> referenceable
| ./api/ocm/extensions/accessmethods/ocm/cli_test.go:29: ot ==> to, of, or, not, it
| ./api/ocm/extensions/accessmethods/ocm/cli_test.go:30: ot ==> to, of, or, not, it
| ./api/ocm/extensions/accessmethods/options/types.go:23: ot ==> to, of, or, not, it
| ./api/ocm/extensions/accessmethods/options/types.go:24: ot ==> to, of, or, not, it
| ./api/ocm/extensions/accessmethods/options/types.go:24: ot ==> to, of, or, not, it
| ./api/ocm/extensions/accessmethods/plugin/cmd_test.go:54: ot ==> to, of, or, not, it
| ./api/ocm/extensions/accessmethods/plugin/cmd_test.go:55: ot ==> to, of, or, not, it
| ./api/ocm/extensions/accessmethods/s3/method_test.go:153: comsumer ==> consumer
| ./api/ocm/extensions/blobhandler/doc.go:7: contect ==> contact, context, connect
| ./api/ocm/extensions/blobhandler/handlers/generic/maven/blobhandler_test.go:44: sofware ==> software
| ./api/ocm/extensions/blobhandler/handlers/generic/maven/blobhandler_test.go:53: sofware ==> software
| ./api/ocm/extensions/blobhandler/handlers/generic/maven/blobhandler_test.go:58: sofware ==> software
| ./api/ocm/extensions/blobhandler/handlers/generic/maven/blobhandler_test.go:59: sofware ==> software
| ./api/ocm/extensions/download/doc.go:2: resoures ==> resources
| ./api/ocm/extensions/download/handlers/plugin/handler.go:46: downlowd ==> download
| ./api/ocm/extensions/repositories/ctf/repo_test.go:161: bloc ==> block
| ./api/ocm/extensions/repositories/genericocireg/componentversion.go:35: acess ==> access
| ./api/ocm/extensions/repositories/genericocireg/state.go:130: softwares ==> software
| ./api/ocm/extensions/repositories/genericocireg/state.go:133: erro ==> error
| ./api/ocm/extensions/repositories/virtual/componentversion.go:18: acess ==> access
| ./api/ocm/internal/blobhandler.go:234: independend ==> independent
| ./api/ocm/internal/blobhandler_test.go:156: priortizes ==> prioritizes
| ./api/ocm/internal/blobhandler_test.go:173: priortizes ==> prioritizes
| ./api/ocm/internal/blobhandler_test.go:188: priortizes ==> prioritizes
| ./api/ocm/internal/blobhandler_test.go:204: priortizes ==> prioritizes
| ./api/ocm/internal/repotypes.go:32: convertable ==> convertible
| ./api/ocm/ocmutils/check/check_test.go:41: refereces ==> references
| ./api/ocm/plugin/cache/updater.go:172: uptodate ==> up-to-date
| ./api/ocm/plugin/cache/updater.go:191: uptodate ==> up-to-date
| ./api/ocm/plugin/cache/updater.go:225: uptodate ==> up-to-date
| ./api/ocm/plugin/common/describe.go:551: Contraints ==> Constraints
| ./api/ocm/plugin/plugin.go:105: configration ==> configuration
| ./api/ocm/plugin/plugin.go:110: configration ==> configuration
| ./api/ocm/plugin/ppi/cmds/logging.go:14: configration ==> configuration
| ./api/ocm/plugin/ppi/interface.go:93: mehod ==> method
| ./api/ocm/plugin/ppi/interface.go:178: mehod ==> method
| ./api/ocm/plugin/ppi/plugin.go:550: allowd ==> allowed, allow, allows
| ./api/ocm/tools/signing/handle.go:717: versio ==> version
| ./api/ocm/tools/signing/signing_test.go:1253: rembers ==> remembers, renumbers, members
| ./api/ocm/tools/transfer/options.go:27: implemetations ==> implementations
| ./api/ocm/tools/transfer/transfer.go:313: fo ==> of, for, to, do, go
| ./api/ocm/tools/transfer/transferhandler/transferhandler.go:40: hander ==> handler
| ./api/ocm/valuemergehandler/handlers/maplistmerge/handler.go:60: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/maplistmerge/handler.go:61: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/maplistmerge/handler.go:63: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/maplistmerge/handler.go:67: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/maplistmerge/handler.go:67: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/maplistmerge/handler.go:72: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplelistmerge/handler.go:37: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplelistmerge/handler.go:38: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplelistmerge/handler.go:48: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplelistmerge/handler.go:50: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplelistmerge/handler.go:54: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplelistmerge/handler.go:62: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplemapmerge/handler.go:50: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplemapmerge/handler.go:51: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplemapmerge/handler.go:56: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplemapmerge/handler.go:56: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/handlers/simplemapmerge/handler.go:61: te ==> the, be, we, to
| ./api/ocm/valuemergehandler/hpi/logging.go:7: marge ==> merge
| ./api/tech/oras/interface.go:25: Dependending ==> Depending
| ./api/tech/signing/handlers/sigstore/attr/attr.go:79: invalud ==> invalid
| ./api/tech/signing/handlers/sigstore/handler.go:113: certifcate ==> certificate
| ./api/tech/signing/handlers/sigstore/handler.go:143: valiate ==> validate
| ./api/tech/signing/rules.go:146: arry ==> array, carry
| ./api/tech/signing/rules.go:330: arry ==> array, carry
| ./api/tech/signing/rules.go:371: arry ==> array, carry
| ./api/tech/signing/rules.go:417: arry ==> array, carry
| ./api/utils/accessobj/accessstate.go:133: pinter ==> pointer, printer
| ./api/utils/blobaccess/blobaccess/other.go:30: bloc ==> block
| ./api/utils/blobaccess/blobaccess/other.go:34: wil ==> will, well
| ./api/utils/blobaccess/dockermulti/access.go:71: versio ==> version
| ./api/utils/logging/logging.go:75: loosing ==> losing
| ./api/utils/misc/printer_test.go:54: loggging ==> logging
| ./api/utils/panics/panics_test.go:27: catched ==> caught
| ./api/utils/panics/panics_test.go:38: catched ==> caught
| ./api/utils/refmgmt/resource/suite_test.go:12: Referencable ==> Referenceable
| ./api/utils/refmgmt/suite_test.go:12: Referencable ==> Referenceable
| ./api/utils/registrations/registrations.go:4: vor ==> for
| ./api/utils/runtime/multi_test.go:24: wth ==> with
| ./api/utils/runtime/unstructured.go:29: firt ==> first, flirt
| ./api/utils/runtime/unstructured_test.go:16: InOut ==> input, in out
| ./api/utils/runtime/unstructured_test.go:62: InOut ==> input, in out
| ./api/utils/runtime/unstructured_test.go:67: InOut ==> input, in out
| ./api/utils/runtime/unstructured_test.go:74: InOut ==> input, in out
| ./api/utils/runtime/unstructured_test.go:79: InOut ==> input, in out
| ./api/utils/runtime/validate.go:7: Validater ==> Validator, Validated, Validates, Validate
| ./api/utils/runtime/validate.go:17: Validater ==> Validator, Validated, Validates, Validate
| ./api/utils/runtime/versionedtype.go:68: paramerized ==> parameterized
| ./api/utils/subst/subst.go:137: unecessarily ==> unnecessarily
| ./api/utils/subst/subst.go:193: nd ==> and, 2nd
| ./api/utils/subst/subst.go:199: nd ==> and, 2nd
| ./api/utils/subst/subst_test.go:187: subtitution ==> substitution
| ./cmds/helminstaller/app/execute.go:207: repositry ==> repository
| ./cmds/ocm/commands/misccmds/hash/sign/cmd.go:82: argumnt ==> argument
| ./cmds/ocm/commands/ocicmds/artifacts/transfer/cmd.go:174: equired ==> required, enquired
| ./cmds/ocm/commands/ocicmds/common/handlers/artifacthdlr/closure.go:37: wit ==> with
| ./cmds/ocm/commands/ocicmds/tags/show/cmd_test.go:17: NAMESAPCE ==> NAMESPACE
| ./cmds/ocm/commands/ocicmds/tags/show/cmd_test.go:33: NAMESAPCE ==> NAMESPACE
| ./cmds/ocm/commands/ocicmds/tags/show/cmd_test.go:78: NAMESAPCE ==> NAMESPACE
| ./cmds/ocm/commands/ocicmds/tags/show/cmd_test.go:92: NAMESAPCE ==> NAMESPACE
| ./cmds/ocm/commands/ocicmds/tags/show/cmd_test.go:102: NAMESAPCE ==> NAMESPACE
| ./cmds/ocm/commands/ocicmds/tags/show/cmd_test.go:115: NAMESAPCE ==> NAMESPACE
| ./cmds/ocm/commands/ocmcmds/common/handlers/comphdlr/closure.go:34: wit ==> with
| ./cmds/ocm/commands/ocmcmds/common/inputs/cpi/helper.go:138: imput ==> input
| ./cmds/ocm/commands/ocmcmds/common/options/comppathopt/option.go:42: accets ==> accepts
| ./cmds/ocm/commands/ocmcmds/common/options/optutils/registration.go:60: nam ==> name
| ./cmds/ocm/commands/ocmcmds/common/options/optutils/registration.go:63: nam ==> name
| ./cmds/ocm/commands/ocmcmds/common/options/optutils/registration.go:65: nam ==> name
| ./cmds/ocm/commands/ocmcmds/common/options/optutils/registration.go:66: nam ==> name
| ./cmds/ocm/commands/ocmcmds/common/options/optutils/registration.go:66: nam ==> name
| ./cmds/ocm/commands/ocmcmds/common/options/optutils/registration.go:115: nam ==> name
| ./cmds/ocm/commands/ocmcmds/components/check/cmd_test.go:38: refereces ==> references
| ./cmds/ocm/commands/ocmcmds/components/get/cmd_test.go:148: constrainted ==> constrained
| ./cmds/ocm/commands/ocmcmds/components/get/cmd_test.go:159: constrainted ==> constrained
| ./cmds/ocm/commands/ocmcmds/components/list/cmd_test.go:128: constrainted ==> constrained
| ./cmds/ocm/commands/ocmcmds/components/list/cmd_test.go:139: constrainted ==> constrained
| ./cmds/ocm/commands/ocmcmds/references/add/cmd_test.go:60: wth ==> with
| ./cmds/ocm/commands/ocmcmds/references/get/cmd_test.go:93: lits ==> list
| ./cmds/ocm/commands/ocmcmds/resources/download/cmd.go:152: fot ==> for, fit, dot, rot, cot, got, tot, fog
| ./cmds/ocm/commands/ocmcmds/resources/get/cmd_test.go:54: ambigious ==> ambiguous
| ./cmds/ocm/commands/ocmcmds/routingslips/get/cmd_test.go:108: te ==> the, be, we, to
| ./cmds/ocm/commands/ocmcmds/routingslips/get/cmd_test.go:112: te ==> the, be, we, to
| ./cmds/ocm/commands/ocmcmds/sources/get/cmd_test.go:54: ambigious ==> ambiguous
| ./cmds/ocm/common/options/interfaces.go:156: woth ==> worth, with
| ./cmds/ocm/common/utils/command.go:177: ond ==> one, and
| ./cmds/ocm/common/utils/handling.go:26: intials ==> initials
| ./cmds/ocm/topics/toi/bootstrapping/topic.go:1: bootstapping ==> bootstrapping
| ./config/crd/bases/ocm.open-component-model.software_componentdescriptors.yaml:68: ist ==> is, it, its, it's, sit, list
| ./config/crd/bases/ocm.open-component-model.software_componentdescriptors.yaml:193: ist ==> is, it, its, it's, sit, list
| ./config/crd/bases/ocm.open-component-model.software_componentdescriptors.yaml:304: ist ==> is, it, its, it's, sit, list
| ./config/crd/bases/ocm.open-component-model.software_componentdescriptors.yaml:416: ist ==> is, it, its, it's, sit, list
| ./config/crd/bases/ocm.open-component-model.software_componentdescriptors.yaml:493: ist ==> is, it, its, it's, sit, list
| ./config/crd/bases/ocm.open-component-model.software_componentdescriptors.yaml:604: ist ==> is, it, its, it's, sit, list
| ./examples/lib/comparison-scenario/00-consumer.go:73: compoment ==> component
| ./examples/lib/tour/01-getting-started/example.go:195: abount ==> about
| ./examples/lib/tour/02-composing-a-component-version/01-basic-componentversion-creation.go:242: wee ==> we
| ./examples/lib/tour/03-working-with-credentials/common.go:196: wee ==> we
| ./examples/lib/tour/05-transporting-component-versions/common.go:194: wee ==> we
| ./examples/lib/tour/06-signing-component-versions/common.go:200: wee ==> we
```