### PR TITLE
chore: temporarily use master as version

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       gosec-args:
         description: "Arguments passed to 'gosec' - see: https://github.com/securego/gosec/blob/HEAD/README.md#usage"
-        default: "-fmt sarif -out results.sarif -no-fail -show-ignored ./..."
+        default: "-fmt sarif -out results.sarif -no-fail ./..."
         type: string
 
 jobs:

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -12,6 +12,8 @@ jobs:
   gosec:
     name: Go Security Checker
     runs-on: large_runner
+    container:
+      image: securego/gosec:2.22.1 # needs to be set as the securego/gosec@v2.22.1 uses the securego/gosec:2.22.0 image
     permissions:
       # Required to upload SARIF files
       security-events: write
@@ -21,7 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.22.1 # switch back to versions until dependabot can handle pinned commits
+        # need to set @master as the action always uses the last but not least version
+        # e.g. securego/gosec@v2.22.1 uses the securego/gosec:2.22.0 image
+        # but we require support for go 1.24 which comes with 2.22.1
+        uses: securego/gosec@master
         with:
           args: "${{ inputs.gosec-args }}"
       - name: Upload SARIF file


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
temporarily use master as version