### PR TITLE
chore: add failure severity parameters to Black Duck SCA scan workflow

### DIFF
--- a/.github/workflows/bdba.yaml
+++ b/.github/workflows/bdba.yaml
@@ -121,7 +121,7 @@ jobs:
 
             # Upload the file using curl
             echo "Uploading $upload_name to BDBA"
-            curl_output=$(curl -sS -X PUT -H "Authorization: Bearer ${{ steps.generate-bdba-token.outputs.bdba_token }}" -H "Group: ${{ secrets.BDBA_GROUP_ID }}" -H "Version: $version" --data-binary "@$file" "$api_url")
+            curl_output=$(curl -sS -X PUT -H "Authorization: Bearer ${{ steps.generate-bdba-token.outputs.bdba_token }}" -H "Group: ${{ secrets.BDBA_GROUP_ID }}" -H "Version: $version" -H "Delete-Binary: true" --data-binary "@$file" "$api_url")
 
             # Check if upload was successful and print results
             if [[ $(echo "$curl_output" | jq '.meta.code') == "200" ]]; then

--- a/.github/workflows/blackduck-scan.yaml
+++ b/.github/workflows/blackduck-scan.yaml
@@ -46,6 +46,10 @@ jobs:
           blackducksca_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
           blackducksca_scan_full: true
           blackducksca_scan_failure_severities: 'BLOCKER,CRITICAL'
+          # Parameter required to avoid failing the build even if policy violations are found.
+          # Scan results are nonetheless uploaded to Blackduck SCA backend.
+          # !!! THEY SHOULD BE REMOVED ONCE WE TRIAGED ALL FINDINGS AND THE SCAN RESULTS ARE STABLE !!!
+          mark_build_status: success
 
       - name: Run Black Duck SCA Scan (Pull Requests)
         if: ${{ inputs.event_type == 'pull_request_target' }} 
@@ -60,9 +64,8 @@ jobs:
           blackducksca_url: ${{ secrets.BLACKDUCK_URL }}
           blackducksca_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
           blackducksca_scan_full: false
-          # Following parameters are required to be set to avoid failing the build even if policy violations are found.
-          # THEY SHOULD BE REMOVED ONCE WE TRIAGED ALL FINDINGS AND THE SCAN RESULTS ARE STABLE.
-          blackducksca_scan_failure_severities: 'NONE'
+          # Parameter required to avoid failing the build even if policy violations are found.
+          # !!! THEY SHOULD BE REMOVED ONCE WE TRIAGED ALL FINDINGS AND THE SCAN RESULTS ARE STABLE !!!
           mark_build_status: success
 
 

--- a/.github/workflows/blackduck-scan.yaml
+++ b/.github/workflows/blackduck-scan.yaml
@@ -45,6 +45,7 @@ jobs:
           blackducksca_url: ${{ secrets.BLACKDUCK_URL }}
           blackducksca_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
           blackducksca_scan_full: true
+          blackducksca_scan_failure_severities: 'BLOCKER,CRITICAL'
 
       - name: Run Black Duck SCA Scan (Pull Requests)
         if: ${{ inputs.event_type == 'pull_request_target' }} 
@@ -59,6 +60,11 @@ jobs:
           blackducksca_url: ${{ secrets.BLACKDUCK_URL }}
           blackducksca_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
           blackducksca_scan_full: false
+          # Following parameters are required to be set to avoid failing the build even if policy violations are found.
+          # THEY SHOULD BE REMOVED ONCE WE TRIAGED ALL FINDINGS AND THE SCAN RESULTS ARE STABLE.
+          blackducksca_scan_failure_severities: 'NONE'
+          mark_build_status: success
+
 
       # Check Black Duck status and upload status file as artifact.
       # This step is required to be set as always(), so the status file is uploaded even if the Black Duck scan fails.


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>
Signed-off-by: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Don't fail PR check until team has triaged all existing policy violations. For Full Scans on push event fail build if BLOCKER or CRITICAL issues are found (following policy).