### PR TITLE
chore: add ocm-controller exception

### DIFF
--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -81,7 +81,7 @@ rulesets:
         # Array of repository names or patterns to exclude. The
         # condition will not pass if any of these patterns
         # match.
-        exclude: ['.github', 'jenkins-library', 'cobra', 'delivery-*', 'ocm-gear*', 'prometheus']
+        exclude: ['.github', 'jenkins-library', 'cobra', 'delivery-*', 'ocm-gear*', 'prometheus', 'ocm-controller']
         # Whether renaming of target repositories is
         # prevented.
         protected: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

ocm-controller's release process is a remnant of the old days. It has non-linear commit history by creating merge commits during the release process. This is sub-optimal, but since we are moving away from it (from ocm-controller), to fix it is time and effort that we do not want to spend at this time.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->