### PR TITLE
chore: set squash merge commit defaults

### DIFF
--- a/safe-settings/suborgs/ocm.yml
+++ b/safe-settings/suborgs/ocm.yml
@@ -70,6 +70,18 @@ repository:
   # squash-merging.
   allow_squash_merge: true
 
+  # Required when using `squash_merge_commit_message`.
+  # The default value for a squash merge commit title:
+  # - `PR_TITLE` - default to the pull request's title.
+  # - `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).
+  squash_merge_commit_title: PR_TITLE
+
+  # The default value for a squash merge commit message:
+  # - `PR_BODY` - default to the pull request's body.
+  # - `COMMIT_MESSAGES` - default to the branch's commit messages.
+  # - `BLANK` - default to a blank commit message.
+  squash_merge_commit_message: PR_BODY
+
   # Either `true` to allow merging pull requests with a merge commit, or `false`
   # to prevent merging pull requests with merge commits.
   allow_merge_commit: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
set squash merge commit title default to PR_TITLE and squash merge commit message to PR_BODY

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->