### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rotate-bdba-token.yml
+++ b/.github/workflows/rotate-bdba-token.yml
@@ -1,6 +1,9 @@
 # Rotate Black Duck Binary Analysis API token on a monthly basis
 # The token is used in the worklfow bdba.yaml and stored as a secret on org level
 name: BDBA Token Rotation
+permissions:
+  contents: read
+  secrets: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/open-component-model/.github/security/code-scanning/2](https://github.com/open-component-model/.github/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it needs `contents: read` to check out the repository and `secrets: write` to update the organization secret. These permissions will be explicitly set to ensure the workflow operates securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
