### PR TITLE
chore: add collaborators by default with triage permission to all org repos

### DIFF
--- a/safe-settings/suborgs/ocm.yml
+++ b/safe-settings/suborgs/ocm.yml
@@ -266,6 +266,8 @@ teams:
   permission: maintain
 - name: Admins
   permission: admin
+- name: Collaborators
+  permission: triage
 
 # Branch protection rules
 # See https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection for available options


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

We are missing collaborators assignments with triage permission for the suborg

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->