### PR TITLE
update project readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,7 @@ OCM is an open standard and toolkit for packaging, signing, transporting, and de
 
 ## :handshake: OCM and ApeiroRA
 
-OCM extends ApeiroRA's Platform Mesh principles by providing secure, reliable delivery and deployment of software - across cloud, on-prem, hybrid, and even air-gapped environments. By decoupling and streamlining lifecycle processes like compliance checks, security scans, and deployments, OCM helps teams collaborate more effectively and build trust into every step of the software supply chain.
+OCM extends [ApeiroRA's](https://apeirora.eu) Platform Mesh principles by providing secure, reliable delivery and deployment of software - across cloud, on-prem, hybrid, and even air-gapped environments. By decoupling and streamlining lifecycle processes like compliance checks, security scans, and deployments, OCM helps teams collaborate more effectively and build trust into every step of the software supply chain.
 
 ## :pushpin: OCM and NeoNephos
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,27 +1,21 @@
-# Open Component Model Community
+# Open Component Model
 
-Welcome to the Open Component Model community!
+Deliver and deploy your software securely — anywhere, at any scale.
 
-This repository outlines all the necessary steps to get started with learning about, using, and contributing to the OCM projects.
-You can find all this and much, much more also on our [web page](https://ocm.software).
+OCM is an open standard and toolkit for packaging, signing, transporting, and deploying software across any boundary, including air-gapped environments. For full documentation, visit [ocm.software](https://ocm.software).
 
-## What is the Open Component Model?
+## Projects
 
-The Open Component Model provides a standard for describing delivery artifacts that can be accessed from many types of component repositories.
+- [OCM Specification](https://github.com/open-component-model/ocm-spec) - The `ocm-spec` repository contains the OCM specification, which provides a formal description of OCM and its format to describe software artifacts and a storage layer to persist those and make them accessible from remote.
+- [Open Component Model](https://github.com/open-component-model/open-component-model) - The main repository containing the OCM library, CLI, and Kubernetes toolkit. This is where active development happens.
+- [OCM CLI](https://github.com/open-component-model/open-component-model/tree/main/cli) - The `ocm` command line interface makes it easy to create, sign, verify, and transfer component versions as well as embed them in build processes.
+- [OCM K8s Toolkit](https://github.com/open-component-model/open-component-model/tree/main/kubernetes/controller) - A Kubernetes operator to deploy OCM resources into a Kubernetes cluster.
+- [Open Delivery Gear](https://github.com/open-component-model/open-delivery-gear) - An extensible and cloud-native compliance delivery engine.
 
-The following projects build the foundation of OCM:
+## Getting Started
 
-- [OCM Specification](https://github.com/open-component-model/ocm-spec/blob/main/README.md) - The `ocm-spec` repository contains the OCM specification, which provides a formal description of OCM and its format to describe software artifacts and a storage layer to persist those and make them accessible from remote.
-- [OCM Core Library](https://github.com/open-component-model/ocm#ocm-library) - The `ocm` core library is written in Golang and contains an API for interacting with OCM elements. A guided tour how to work with the library can be found [here](https://github.com/open-component-model/ocm/tree/main/examples/lib/tour#readme).
-- [OCM CLI](https://github.com/open-component-model/ocm#ocm-cli) - With the `ocm` command line interface end users can interact with OCM elements. It makes it easy to create component versions and embed them in CI and CD processes. Examples can be found in [this Makefile](https://github.com/open-component-model/ocm/blob/main/examples/make/Makefile).
-- [OCM Controller](https://github.com/open-component-model/ocm-controller) - The `ocm-controllers` are designed to enable the automated deployment of software using the [Open Component Model](https://ocm.software) and Flux.
-- [OCM Website](https://github.com/open-component-model/ocm-website) - The `ocm-website` you are currently visiting. It is built using Hugo and hosted on Netlify.
-
-Here are some suggested starting points:
-
-- Read about the [problem statement](https://github.com/open-component-model/ocm-spec/tree/main/doc/introduction) that the OCM set of solutions can help to solve.
-- Start with the documentation about [Model Elements](https://github.com/open-component-model/ocm-spec/blob/main/doc/01-model/02-elements-toplevel.md#model-elements).
-- Check out this [demo](https://github.com/open-component-model/demo-secure-delivery) that shows an end-2-end scenario in an air-gapped environment, integrating OCM with [Flux](https://github.com/fluxcd/flux2).
+- Read the [documentation overview](https://ocm.software/docs/overview/) to understand what OCM offers.
+- Follow the [Getting Started](https://ocm.software/docs/getting-started/) guide to quickly get hands-on with OCM.
 
 ## :handshake: OCM and ApeiroRA
 
@@ -35,4 +29,4 @@ OCM has been donated to the NeoNephos Foundation, a Linux Foundation initiative 
 
 We welcome all contributions from the community!
 
-Please read the [Contributing Guide](https://github.com/open-component-model/community/tree/main/CONTRIBUTING.md) for instructions on how to contribute.
+Please read the [Contributing Guide](https://ocm.software/community/contributing/) for instructions on how to contribute.


### PR DESCRIPTION
#### What this PR does / why we need it

Rewrites the org profile README to better serve as a GitHub landing page:

- Replaces the self-referential "this repository" intro with OCM's value proposition
- Updates project list to reflect the consolidated monorepo structure
- Points documentation and contributing links to ocm.software instead of stale GitHub paths
- Adds link to ApeiroRA website

#### Which issue(s) this PR is related to

N/A