### PR TITLE
compliance(DCO): Enforce rulesets also for ODG repositories

### DIFF
--- a/labels/label_mappings.json
+++ b/labels/label_mappings.json
@@ -1,6 +1,5 @@
 {
     "area/open-source": "area/community",
-    "component/ocm-website": "area/documentation",
     "area/networking": "area/network",
     "testing": "area/testing",
     "github-actions": "component/github-actions",

--- a/safe-settings/config.yml
+++ b/safe-settings/config.yml
@@ -5,9 +5,6 @@ restrictedRepos:
     - '^\.github$'
     - '^jenkins-library$'
     - '^cobra$'
-    - '^delivery-*'
-    - '^ocm-gear$'
-    - '^prometheus$'
     - '^vscode-ocm-tools$' # archived
     - '^ocm-k8s-toolkit$' # archived
     - 'service-model' # archived

--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -62,7 +62,7 @@ rulesets:
         # Array of repository names or patterns to exclude. The
         # condition will not pass if any of these patterns
         # match.
-        exclude: ['.github', 'jenkins-library', 'cobra', 'delivery-*', 'ocm-gear*', 'prometheus', 'ocm-controller']
+        exclude: ['.github', 'jenkins-library', 'cobra', 'ocm-controller']
         # Whether renaming of target repositories is
         # prevented.
         protected: true

--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -42,6 +42,9 @@ rulesets:
       - actor_id: 295948 # ocm-bot
         actor_type: Integration
         bypass_mode: always
+      - actor_id: 2439345 # odg ci (https://github.com/apps/federated-github-access)
+        actor_type: Integration
+        bypass_mode: always
     conditions:
       # Parameters for a repository ruleset ref name condition
       ref_name:

--- a/safe-settings/suborgs/ocm.yml
+++ b/safe-settings/suborgs/ocm.yml
@@ -2,7 +2,6 @@
 suborgrepos:
   - demo-secure-delivery
   - homebrew-tap
-  - internal-processes
   - ocm
   - ocm-action
   - ocm-controller
@@ -12,7 +11,6 @@ suborgrepos:
   - ocm-project
   - ocm-setup-action
   - ocm-spec
-  - ocm-website
   - open-component-model
   - pkg
   - podinfo
@@ -161,9 +159,6 @@ labels:
 - name: component/ocm-spec
   color: 25399e
   description: Open Component Model Specification
-- name: component/ocm-website
-  color: 25399e
-  description: https://ocm.software/
 - name: component/github-actions
   color: 25399e
   description: Changes on GitHub Actions or within `.github/` directory


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Do not exclude ODG repositories from branch-protections (enforcing DCO and other things) anymore.

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->
https://github.com/open-component-model/open-delivery-gear/issues/67