### PR TITLE
chore: re-create release-drafter and removal of kind/poc, deprecation, refactor

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,42 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-template: '$COMPLETE'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&#@`'
+template: |
+  # Release v$RESOLVED_VERSION
+
+  $CHANGES
+exclude-labels:
+- 'kind/skip-release-notes'
+- 'dev/wont-fix'
+- 'component/github-actions'
+categories:
+- title: '⚠️ Breaking Changes'
+  labels:
+  - '!BREAKING-CHANGE!'
+- title: '🚀 Features'
+  labels:
+  - 'kind/feature'
+  - 'kind/poc'
+- title: '🐛 Bug Fixes'
+  collapse-after: 5
+  labels:
+  - 'kind/bugfix'
+- title: '📄 Documentation'
+  collapse-after: 5
+  labels:
+  - 'area/documentation'
+- title: '🥺 Deprecation'
+  collapse-after: 3
+  labels:
+  - 'kind/deprecation'
+- title: '🧰 Maintenance'
+  collapse-after: 3
+  labels:
+  - 'kind/chore'
+  - 'kind/refactor'
+- title: '⬆️ Dependencies'
+  collapse-after: 3
+  labels:
+  - 'kind/dependency'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,7 +21,6 @@ categories:
 - title: '🚀 Features'
   labels:
   - 'kind/feature'
-  - 'kind/poc'
 - title: '🐛 Bug Fixes'
   collapse-after: 5
   labels:
@@ -30,15 +29,10 @@ categories:
   collapse-after: 5
   labels:
   - 'area/documentation'
-- title: '🥺 Deprecation'
-  collapse-after: 3
-  labels:
-  - 'kind/deprecation'
 - title: '🧰 Maintenance'
   collapse-after: 3
   labels:
   - 'kind/chore'
-  - 'kind/refactor'
 - title: '⬆️ Dependencies'
   collapse-after: 3
   labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,6 @@
+# This file is used by the Release Drafter GitHub Action to automatically generate release notes, in case no repo-local drafter is defined.
+# Used by https://github.com/open-component-model/ocm-controller and https://github.com/open-component-model/ocm
+
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 version-template: '$COMPLETE'

--- a/labels/label_mappings.json
+++ b/labels/label_mappings.json
@@ -8,8 +8,6 @@
     "fix": "kind/bugfix",
     "bug": "kind/bugfix",
     "kind/enhancement": "kind/feature",
-    "Task": "kind/task",
-    "task": "kind/task",
     "good first issue": "kind/good-first-issue",
     "chore": "kind/chore",
     "dependencies": "kind/dependency",

--- a/safe-settings/suborgs/ocm.yml
+++ b/safe-settings/suborgs/ocm.yml
@@ -172,21 +172,12 @@ labels:
 - name: kind/good-first-issue
   color: 7057ff
   description: Good for newcomers
-- name: kind/poc
-  color: c7def8
-  description: Proof of Concept or Prototype
 - name: kind/chore
   color: c7def8
   description: chore, maintenance, etc.
 - name: kind/dependency
   color: c7def8
   description: dependency update, etc.
-- name: kind/refactor
-  color: c7def8
-  description: refactoring, maintenance, etc.
-- name: kind/deprecation
-  color: c7def8
-  description: whenever something gets deprecated
 - name: kind/skip-release-notes
   color: c7def8
   description: Pull request will not appear in release notes


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Re-creates the release-drafter as it was deleted by mistake, it is still used in https://github.com/open-component-model/ocm and https://github.com/open-component-model/ocm-controller
- Removed the kind/epic label from changelog detection as well as kind/poc, kind/deprecation and kind/refactor 
- Removed kind/poc, kind/deprecation and kind/refactor from settings-syncer

#### Which issue(s) this PR is related to
https://github.com/open-component-model/ocm-project/issues/1216
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->